### PR TITLE
fix: prevent model list truncation when intro is short

### DIFF
--- a/clients/orbitchat/src/components/ModelPickerButton.tsx
+++ b/clients/orbitchat/src/components/ModelPickerButton.tsx
@@ -83,7 +83,7 @@ export function ModelPickerButton({
             <div
               role="listbox"
               aria-label={listboxLabel}
-              className="absolute right-0 bottom-full z-50 mb-1.5 min-w-[200px] overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg dark:border-[#2f303d] dark:bg-[#111111]"
+              className="absolute right-0 bottom-full z-50 mb-1.5 min-w-[200px] max-h-60 overflow-y-auto rounded-xl border border-gray-200 bg-white shadow-lg dark:border-[#2f303d] dark:bg-[#111111]"
             >
               {availableModels.map(model => {
                 const isActive = effectiveModel === model.name;


### PR DESCRIPTION
The model picker dropdown opens upward via `bottom-full`, but when the intro area above is too short, the dropdown is clipped by the viewport boundary.

Added `max-h-60 overflow-y-auto` so the list scrolls instead of being cut off, regardless of available vertical space.

Before: list truncated at viewport edge
After: list capped at 240px with scroll

Fixes #226