### PR TITLE
Exclude unmatched routes from dashboard latency

### DIFF
--- a/server/services/metrics_service.py
+++ b/server/services/metrics_service.py
@@ -227,6 +227,7 @@ class MetricsService:
             return False
 
         excluded_exact_paths = {
+            "__unmatched_route__",
             "/",
             "/favicon.ico",
             "/metrics",

--- a/server/tests/test_middleware/test_metrics_middleware.py
+++ b/server/tests/test_middleware/test_metrics_middleware.py
@@ -13,7 +13,6 @@ import sys
 from pathlib import Path
 from unittest.mock import Mock
 
-import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 

--- a/server/tests/test_services/test_metrics_service.py
+++ b/server/tests/test_services/test_metrics_service.py
@@ -22,3 +22,23 @@ def test_dashboard_total_requests_is_lifetime_count():
 
     assert len(service.request_timestamps) == 1000
     assert dashboard_metrics["requests"]["total"] == 1005
+
+
+def test_dashboard_metrics_excludes_unmatched_route_label():
+    service = MetricsService({"monitoring": {"enabled": True}})
+
+    service.record_request("GET", "__unmatched_route__", 404, 0.01)
+    service.record_request("GET", "/v1/chat/completions", 200, 0.02)
+
+    dashboard_metrics = service.get_dashboard_metrics()
+
+    assert dashboard_metrics["requests"]["total"] == 1
+    assert dashboard_metrics["endpoint_stats"] == [
+        {
+            "endpoint": "/v1/chat/completions",
+            "method": "GET",
+            "total_requests": 1,
+            "avg_latency_ms": 20.0,
+            "error_rate": 0.0,
+        }
+    ]


### PR DESCRIPTION
Fixes #270.

## Summary
- filters the synthetic `__unmatched_route__` label out of dashboard endpoint tracking
- keeps the middleware bounded label behavior for unmatched paths
- adds a regression test for dashboard endpoint stats

## Tests
- `venv/bin/python -m pytest server/tests/test_services/test_metrics_service.py server/tests/test_middleware/test_metrics_middleware.py`
- `venv/bin/python -m ruff check server/services/metrics_service.py server/tests/test_services/test_metrics_service.py server/middleware/metrics_middleware.py server/tests/test_middleware/test_metrics_middleware.py`