### PR TITLE
feat: add privacy_filter moderation provider for local PII detection

### DIFF
--- a/config/moderators.yaml
+++ b/config/moderators.yaml
@@ -15,3 +15,24 @@ moderations:
     top_p: 1.0
     max_tokens: 100  # Increased from 50 to allow full JSON response
     batch_size: 1
+  # Local PII detection using OpenAI's privacy-filter token-classification
+  # model (Apache 2.0, runs on-premises, no API key required).
+  # Requires the 'huggingface' dependency profile (transformers + torch):
+  #   ./install/setup.sh --profile huggingface
+  # Enable by setting safety.moderator: "privacy_filter" in guardrails.yaml.
+  privacy_filter:
+    model: "openai/privacy-filter"
+    device: "auto"        # auto, cpu, cuda, or mps
+    threshold: 0.5        # Minimum span confidence to count a detection
+    # Categories that flag content when detected at or above the threshold.
+    # Detected categories are always reported as pii.<category> scores;
+    # remove entries here to report them without flagging.
+    flag_categories:
+      - "account_number"
+      - "private_address"
+      - "private_email"
+      - "private_person"
+      - "private_phone"
+      - "private_url"
+      - "private_date"
+      - "secret"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1347,6 +1347,22 @@ moderators:
     model: "llama-guard3:1b"
     temperature: 0.0
     batch_size: 1
+
+  # Local PII detection (openai/privacy-filter, no API key required)
+  # Requires the 'huggingface' dependency profile. See docs/security/pii-moderation.md
+  privacy_filter:
+    model: "openai/privacy-filter"
+    device: "auto"        # auto, cpu, cuda, or mps
+    threshold: 0.5        # Minimum span confidence to flag
+    flag_categories:      # Categories that block when detected above threshold
+      - "account_number"
+      - "private_address"
+      - "private_email"
+      - "private_person"
+      - "private_phone"
+      - "private_url"
+      - "private_date"
+      - "secret"
 ```
 
 ## Data Sources Configuration (datasources.yaml)

--- a/docs/security/pii-moderation.md
+++ b/docs/security/pii-moderation.md
@@ -1,0 +1,107 @@
+# PII Moderation with Privacy Filter
+
+ORBIT can detect personally identifiable information (PII) in user messages
+and block them before they reach the LLM, using the `privacy_filter`
+moderation provider. It runs OpenAI's
+[privacy-filter](https://huggingface.co/openai/privacy-filter) model, a
+bidirectional token-classification model (Apache 2.0) that labels PII spans
+in a single forward pass. The model runs fully on-premises through the
+`transformers` library: no API key, no external calls, and a 128k-token
+context window so long messages are processed without chunking.
+
+## How it fits in
+
+`privacy_filter` is a standard moderation provider, selected the same way as
+`openai`, `anthropic`, or `ollama` moderation. When the safety layer is
+enabled, every user message is checked before inference; a message with PII
+detected above the confidence threshold is blocked with the moderation
+refusal message.
+
+Detected spans are reported as `ModerationResult` categories named
+`pii.<category>` with the model's confidence score, so audit logs record
+which PII types were seen.
+
+## Detected categories
+
+| Category | Examples |
+|:---|:---|
+| `private_person` | Personal names |
+| `private_email` | Email addresses |
+| `private_phone` | Phone numbers |
+| `private_address` | Street/home addresses |
+| `account_number` | Bank/account identifiers |
+| `private_url` | Personal URLs |
+| `private_date` | Personal dates (e.g. birth dates) |
+| `secret` | API keys, credentials, tokens |
+
+## Setup
+
+1. Install the `huggingface` dependency profile (transformers + torch):
+
+   ```bash
+   ./install/setup.sh --profile huggingface
+   ```
+
+2. Select the moderator in `config/guardrails.yaml`:
+
+   ```yaml
+   safety:
+     enabled: true
+     moderator: "privacy_filter"
+   ```
+
+3. (Optional) Tune the provider in `config/moderators.yaml`:
+
+   ```yaml
+   moderations:
+     privacy_filter:
+       model: "openai/privacy-filter"   # Or a fine-tuned variant
+       device: "auto"                   # auto, cpu, cuda, or mps
+       threshold: 0.5                   # Minimum span confidence to flag
+       flag_categories:                 # Categories that block when detected
+         - "account_number"
+         - "private_address"
+         - "private_email"
+         - "private_person"
+         - "private_phone"
+         - "private_url"
+         - "private_date"
+         - "secret"
+   ```
+
+The model (~1.5B parameters, 50M active) is downloaded from HuggingFace on
+first startup and cached locally. GPU is not required; CPU inference is
+practical for chat-message-sized inputs.
+
+## Tuning
+
+- **`threshold`** controls the precision/recall tradeoff. Lower values catch
+  more PII but flag more false positives (e.g. public figures' names);
+  higher values only block high-confidence detections.
+- **`flag_categories`** scopes which PII types block a message. Categories
+  removed from the list are still scored and logged (`pii.<category>`), just
+  not flagged. For example, teams that only care about credential leakage
+  can flag only `secret` and `account_number` while still auditing the rest.
+- **`model`** accepts any HuggingFace token-classification model that emits
+  the same label taxonomy, so a fine-tuned variant of privacy-filter can be
+  dropped in for organization-specific label policies.
+
+## Limitations
+
+- **Detection only, no redaction.** A flagged message is blocked, not
+  masked. Redaction (masking PII and letting the request continue) is a
+  possible future enhancement.
+- **Fail-open.** Consistent with ORBIT's other moderators, technical
+  failures (model failed to load, inference error) allow content through
+  with a warning in the logs rather than blocking all traffic. Monitor for
+  `Moderation check failed, allowing content through` if PII leakage is a
+  bigger risk than downtime for your deployment.
+- **Model limitations.** The model is primarily English-trained; recall may
+  drop on non-English text, non-Latin scripts, uncommon name conventions,
+  and novel credential formats. Per the model card, it should be one layer
+  in a privacy-by-design approach, not an anonymization guarantee.
+
+## Verification
+
+- Unit tests: `server/tests/test_services/test_privacy_filter_moderation.py`
+- Scenario playbook: `server/tests/test_services/playbook-pii-moderation.md`

--- a/server/ai_services/implementations/moderation/__init__.py
+++ b/server/ai_services/implementations/moderation/__init__.py
@@ -5,6 +5,7 @@ Available providers:
     - OpenAIModerationService: OpenAI moderation
     - AnthropicModerationService: Anthropic moderation
     - OllamaModerationService: Ollama moderation
+    - PrivacyFilterModerationService: Local PII detection (openai/privacy-filter)
 """
 
 import logging
@@ -17,6 +18,7 @@ _implementations = [
     ('openai_moderation_service', 'OpenAIModerationService'),
     ('anthropic_moderation_service', 'AnthropicModerationService'),
     ('ollama_moderation_service', 'OllamaModerationService'),
+    ('privacy_filter_moderation_service', 'PrivacyFilterModerationService'),
 ]
 
 for module_name, class_name in _implementations:

--- a/server/ai_services/implementations/moderation/privacy_filter_moderation_service.py
+++ b/server/ai_services/implementations/moderation/privacy_filter_moderation_service.py
@@ -1,0 +1,238 @@
+"""
+Privacy Filter moderation service for PII detection.
+
+This implementation uses OpenAI's privacy-filter model, a local bidirectional
+token-classification model for personally identifiable information (PII)
+detection (https://huggingface.co/openai/privacy-filter). The model labels
+an input sequence in a single forward pass and decodes coherent PII spans,
+so it runs fully on-premises with no external API calls.
+
+Detected spans are reported as ModerationResult categories using the
+"pii.<category>" naming scheme (e.g. "pii.private_email"), so this service
+composes with the safety/guardrail configuration like any other moderator.
+"""
+
+import asyncio
+import logging
+from typing import Any, Dict, List
+
+from ...providers import TransformersBaseService
+from ...services import ModerationService, ModerationResult
+from ...base import ServiceType
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "openai/privacy-filter"
+
+# Privacy span categories detected by openai/privacy-filter
+PRIVACY_FILTER_CATEGORIES = [
+    "account_number",
+    "private_address",
+    "private_email",
+    "private_person",
+    "private_phone",
+    "private_url",
+    "private_date",
+    "secret",
+]
+
+
+class PrivacyFilterModerationService(ModerationService, TransformersBaseService):
+    """
+    PII moderation service using the openai/privacy-filter model.
+
+    Runs the model in-process via the transformers token-classification
+    pipeline. Requires the 'huggingface' dependency profile
+    (transformers + torch), installed via:
+        ./install/setup.sh --profile huggingface
+
+    Configuration (config/moderators.yaml under moderations.privacy_filter):
+        model: HuggingFace model id (default: openai/privacy-filter)
+        threshold: minimum span confidence to count a detection (default: 0.5)
+        flag_categories: categories that set is_flagged when detected above
+            the threshold (default: all 8 categories)
+        device: "auto", "cpu", "cuda", or "mps" (default: auto)
+    """
+
+    def __init__(self, config: Dict[str, Any]):
+        """
+        Initialize the privacy filter moderation service.
+
+        Args:
+            config: Configuration dictionary
+        """
+        # Initialize base classes (mirrors the other moderation services)
+        TransformersBaseService.__init__(self, config, ServiceType.MODERATION, "privacy_filter")
+        ModerationService.__init__(self, config, "privacy_filter")
+
+        provider_config = self._extract_provider_config()
+        self.threshold = float(provider_config.get('threshold', 0.5))
+
+        flag_categories = provider_config.get('flag_categories', PRIVACY_FILTER_CATEGORIES)
+        unknown = [c for c in flag_categories if c not in PRIVACY_FILTER_CATEGORIES]
+        if unknown:
+            logger.warning(
+                f"Ignoring unknown privacy filter flag_categories: {unknown}. "
+                f"Valid categories: {PRIVACY_FILTER_CATEGORIES}"
+            )
+        self.flag_categories = {c for c in flag_categories if c in PRIVACY_FILTER_CATEGORIES}
+
+        # Populated during initialize()
+        self.pipeline = None
+
+    def _get_model(self, default_model=None):
+        """Default to the openai/privacy-filter model when none is configured."""
+        return super()._get_model(default_model or DEFAULT_MODEL)
+
+    def _load_model(self) -> None:
+        """Load the token-classification pipeline. Runs in a thread via executor."""
+        try:
+            from transformers import pipeline
+
+            logger.info(f"Loading privacy filter model: {self.model}")
+
+            self.pipeline = pipeline(
+                task="token-classification",
+                model=self.model,
+                device=self.device,
+                aggregation_strategy="simple",
+            )
+
+            # Expose the underlying model/tokenizer so the base class
+            # verify_connection() and close() work unchanged
+            self.model_instance = self.pipeline.model
+            self.tokenizer = self.pipeline.tokenizer
+
+            logger.info(f"Privacy filter model loaded: {self.model} (device={self.device})")
+
+        except ImportError:
+            error_msg = (
+                "transformers package not installed. Install the 'huggingface' "
+                "dependency profile: ./install/setup.sh --profile huggingface"
+            )
+            logger.error(error_msg)
+            raise ImportError(error_msg)
+        except Exception as e:
+            logger.error(f"Error loading privacy filter model: {e}")
+            raise
+
+    def _spans_to_result(self, spans: List[Dict[str, Any]]) -> ModerationResult:
+        """
+        Convert pipeline output spans into a ModerationResult.
+
+        Args:
+            spans: Aggregated entity spans from the token-classification
+                pipeline, each with 'entity_group' and 'score'
+
+        Returns:
+            ModerationResult with pii.<category> scores; flagged when any
+            configured category is detected at or above the threshold
+        """
+        categories: Dict[str, float] = {}
+        is_flagged = False
+
+        for span in spans:
+            label = span.get('entity_group')
+            score = float(span.get('score', 0.0))
+            if label not in PRIVACY_FILTER_CATEGORIES:
+                continue
+
+            key = f"pii.{label}"
+            # Keep the highest-confidence detection per category
+            categories[key] = max(categories.get(key, 0.0), score)
+
+            if label in self.flag_categories and score >= self.threshold:
+                is_flagged = True
+
+        if is_flagged:
+            logger.debug(f"Privacy filter flagged content - categories: {categories}")
+
+        return ModerationResult(
+            is_flagged=is_flagged,
+            categories=categories,
+            provider="privacy_filter",
+            model=self.model
+        )
+
+    async def moderate_content(self, content: str) -> ModerationResult:
+        """
+        Detect PII in content using the privacy filter model.
+
+        Args:
+            content: The text content to moderate
+
+        Returns:
+            ModerationResult object with per-category PII scores
+        """
+        if not self.initialized:
+            if not await self.initialize():
+                logger.warning("Privacy filter initialization failed, allowing content through")
+                return ModerationResult(
+                    is_flagged=False,  # Fail-open, consistent with other moderators
+                    provider="privacy_filter",
+                    model=self.model,
+                    error="Privacy filter initialization failed (allowed)"
+                )
+
+        try:
+            loop = asyncio.get_event_loop()
+            spans = await loop.run_in_executor(self.executor, self.pipeline, content)
+            return self._spans_to_result(spans)
+
+        except Exception as e:
+            logger.error(f"Error in privacy filter moderation: {str(e)}")
+            logger.warning(f"Moderation check failed, allowing content through: {str(e)}")
+            return ModerationResult(
+                is_flagged=False,  # Fail-open on errors
+                provider="privacy_filter",
+                model=self.model,
+                error=f"Moderation check failed (allowed): {str(e)}"
+            )
+
+    async def moderate_batch(self, contents: List[str]) -> List[ModerationResult]:
+        """
+        Moderate multiple content items in a single pipeline call.
+
+        The transformers pipeline natively supports list inputs, so the
+        batch is processed in one executor round trip.
+
+        Args:
+            contents: List of text content to moderate
+
+        Returns:
+            List of ModerationResult objects
+        """
+        if not contents:
+            return []
+
+        if not self.initialized:
+            if not await self.initialize():
+                return [
+                    ModerationResult(
+                        is_flagged=False,
+                        provider="privacy_filter",
+                        model=self.model,
+                        error="Privacy filter initialization failed (allowed)"
+                    )
+                    for _ in contents
+                ]
+
+        try:
+            loop = asyncio.get_event_loop()
+            batch_spans = await loop.run_in_executor(self.executor, self.pipeline, contents)
+            # A single-item list returns one span list rather than a list of lists
+            if len(contents) == 1 and (not batch_spans or isinstance(batch_spans[0], dict)):
+                batch_spans = [batch_spans]
+            return [self._spans_to_result(spans) for spans in batch_spans]
+
+        except Exception as e:
+            logger.error(f"Error in privacy filter batch moderation: {str(e)}")
+            return [
+                ModerationResult(
+                    is_flagged=False,
+                    provider="privacy_filter",
+                    model=self.model,
+                    error=f"Moderation check failed (allowed): {str(e)}"
+                )
+                for _ in contents
+            ]

--- a/server/ai_services/registry.py
+++ b/server/ai_services/registry.py
@@ -130,6 +130,7 @@ def register_moderation_services() -> None:
         ("openai", "OpenAIModerationService", "OpenAI"),
         ("anthropic", "AnthropicModerationService", "Anthropic"),
         ("ollama", "OllamaModerationService", "Ollama"),
+        ("privacy_filter", "PrivacyFilterModerationService", "Privacy Filter (PII)"),
     ])
 
 

--- a/server/tests/test_services/playbook-pii-moderation.md
+++ b/server/tests/test_services/playbook-pii-moderation.md
@@ -1,0 +1,130 @@
+# Manual/Integration Check: PII Moderation (privacy_filter)
+
+End-to-end verification of the `privacy_filter` moderation provider, using a
+real running server and the orbitchat UI. The provider detects personally
+identifiable information (PII) in user messages with OpenAI's
+`openai/privacy-filter` token-classification model, running fully locally.
+
+The automated unit tests (`test_privacy_filter_moderation.py`) already cover
+configuration parsing, span-to-result mapping, threshold and category
+filtering, batch alignment, and fail-open behavior with a mocked pipeline.
+This playbook exercises the real model download and inference path, the
+guardrail integration in the chat pipeline, and the operational config knobs
+(threshold, flag_categories) that unit tests mock away.
+
+Prerequisites:
+
+- The `huggingface` dependency profile is installed
+  (`./install/setup.sh --profile huggingface`). The first run downloads the
+  model (~1.5B params) from HuggingFace; allow a few minutes and disk space.
+- ORBIT runs at `http://localhost:3000` with an API key bound to any
+  chat-capable adapter.
+- orbitchat UI running against the server (`cd clients/orbitchat && npm run dev`).
+
+## 0. Enable PII moderation
+
+In `config/guardrails.yaml`:
+
+```yaml
+safety:
+  enabled: true
+  moderator: "privacy_filter"
+```
+
+The `moderations.privacy_filter` block in `config/moderators.yaml` works
+as shipped (all 8 categories flagged at threshold 0.5). Restart ORBIT and
+confirm the model loads:
+
+```
+Loading privacy filter model: openai/privacy-filter
+Privacy filter model loaded: openai/privacy-filter (device=...)
+Safety service using moderator: privacy_filter
+```
+
+## 1. Baseline: benign message passes
+
+In orbitchat, send:
+
+> What are your support hours?
+
+Expected: a normal answer. No moderation warnings in the server log.
+
+## 2. Personal identifiers are blocked
+
+Send each of the following as separate messages:
+
+> Hi, my name is Alice Smith and my email is alice.smith@example.com
+
+> Call me back at 416-555-0192
+
+> I live at 22 Baker Street, Toronto
+
+Expected: each message is blocked with the moderation refusal message
+instead of a normal answer. The server log shows
+`Message blocked by Moderator Service` and (at DEBUG level) the detected
+categories, e.g. `pii.private_person`, `pii.private_email`,
+`pii.private_phone`, `pii.private_address`.
+
+## 3. Secrets are blocked
+
+Send:
+
+> Here is our API key: sk-live-4f8a2b91c3d7e6f0a1b2c3d4
+
+Expected: blocked, with `pii.secret` in the logged categories.
+
+## 4. Threshold tuning
+
+In `config/moderators.yaml`, set:
+
+```yaml
+  privacy_filter:
+    threshold: 0.99
+```
+
+Restart, then resend the message from step 2. High-confidence detections
+(clear emails/names) should still block. Now try an ambiguous case:
+
+> ask about smith
+
+Expected: passes at 0.99 (low-confidence person-name detection no longer
+crosses the threshold). Reset `threshold: 0.5` afterwards.
+
+## 5. Category scoping
+
+In `config/moderators.yaml`, remove `private_date` from `flag_categories`
+(leave the others). Restart, then send:
+
+> I was born on March 12, 1988
+
+Expected: the message passes; if DEBUG logging is on, `pii.private_date`
+still appears in the category scores (reported but not flagged). A message
+containing an email still blocks. Restore the full list afterwards.
+
+## 6. Fail-open on model failure
+
+In `config/moderators.yaml`, set `model: "openai/does-not-exist"` and
+restart. Send a message containing an email address.
+
+Expected: the message is NOT blocked (moderation fails open, consistent
+with the other moderators), and the server log shows a warning such as
+`Moderation check failed, allowing content through` or
+`Privacy filter initialization failed`. Restore
+`model: "openai/privacy-filter"` afterwards.
+
+> Note: fail-open means a moderation outage silently disables PII blocking.
+> If your deployment treats PII leakage as worse than downtime, monitor for
+> these warnings.
+
+## 7. No regressions for other moderators
+
+Set `safety.moderator` back to your previous provider (e.g. `openai` or
+`ollama`), restart, and send one benign and one unsafe message.
+
+Expected: behavior unchanged from before this feature; the privacy filter
+model is not loaded (no `Loading privacy filter model` log line).
+
+## Cleanup
+
+Restore `config/guardrails.yaml` and `config/moderators.yaml` to their
+original values and restart.

--- a/server/tests/test_services/test_privacy_filter_moderation.py
+++ b/server/tests/test_services/test_privacy_filter_moderation.py
@@ -1,0 +1,219 @@
+"""
+Unit tests for the privacy filter (PII) moderation service.
+
+Tests cover:
+- Configuration parsing (threshold, flag_categories, model default)
+- Span-to-result mapping (thresholds, category filtering, unknown labels)
+- moderate_content and moderate_batch with a mocked pipeline
+- Fail-open behavior on pipeline errors and failed initialization
+
+The transformers pipeline is mocked throughout so no model is downloaded.
+"""
+
+import pytest
+import sys
+import os
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import AsyncMock, MagicMock
+
+# Add the server directory to the Python path
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
+from ai_services.implementations.moderation.privacy_filter_moderation_service import (
+    PrivacyFilterModerationService,
+    PRIVACY_FILTER_CATEGORIES,
+    DEFAULT_MODEL,
+)
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+@pytest.fixture
+def basic_config():
+    """Basic configuration for testing."""
+    return {
+        'moderations': {
+            'privacy_filter': {
+                'device': 'cpu',
+                'threshold': 0.5,
+            }
+        }
+    }
+
+
+def make_service(config):
+    """Create a service instance with a mocked, pre-initialized pipeline."""
+    service = PrivacyFilterModerationService(config)
+    service.initialized = True
+    service.pipeline = MagicMock()
+    service.executor = ThreadPoolExecutor(max_workers=1)
+    return service
+
+
+@pytest.fixture
+def service(basic_config):
+    return make_service(basic_config)
+
+
+def span(label, score, word="x"):
+    """Build a pipeline output span."""
+    return {'entity_group': label, 'score': score, 'word': word}
+
+
+# =============================================================================
+# Configuration parsing
+# =============================================================================
+
+class TestConfiguration:
+
+    def test_model_defaults_to_privacy_filter(self, basic_config):
+        service = PrivacyFilterModerationService(basic_config)
+        assert service.model == DEFAULT_MODEL
+
+    def test_model_override(self, basic_config):
+        basic_config['moderations']['privacy_filter']['model'] = 'my-org/my-finetune'
+        service = PrivacyFilterModerationService(basic_config)
+        assert service.model == 'my-org/my-finetune'
+
+    def test_default_threshold_and_categories(self):
+        service = PrivacyFilterModerationService({'moderations': {'privacy_filter': {'device': 'cpu'}}})
+        assert service.threshold == 0.5
+        assert service.flag_categories == set(PRIVACY_FILTER_CATEGORIES)
+
+    def test_custom_flag_categories(self, basic_config):
+        basic_config['moderations']['privacy_filter']['flag_categories'] = ['secret', 'account_number']
+        service = PrivacyFilterModerationService(basic_config)
+        assert service.flag_categories == {'secret', 'account_number'}
+
+    def test_unknown_flag_categories_ignored(self, basic_config):
+        basic_config['moderations']['privacy_filter']['flag_categories'] = ['secret', 'not_a_category']
+        service = PrivacyFilterModerationService(basic_config)
+        assert service.flag_categories == {'secret'}
+
+
+# =============================================================================
+# Span-to-result mapping
+# =============================================================================
+
+class TestSpansToResult:
+
+    def test_no_spans_is_safe(self, service):
+        result = service._spans_to_result([])
+        assert result.is_flagged is False
+        assert result.categories == {}
+        assert result.provider == 'privacy_filter'
+
+    def test_span_above_threshold_flags(self, service):
+        result = service._spans_to_result([span('private_email', 0.99)])
+        assert result.is_flagged is True
+        assert result.categories == {'pii.private_email': 0.99}
+
+    def test_span_below_threshold_reported_not_flagged(self, service):
+        result = service._spans_to_result([span('private_person', 0.3)])
+        assert result.is_flagged is False
+        assert result.categories == {'pii.private_person': 0.3}
+
+    def test_unflagged_category_reported_not_flagged(self, basic_config):
+        basic_config['moderations']['privacy_filter']['flag_categories'] = ['secret']
+        service = make_service(basic_config)
+        result = service._spans_to_result([span('private_date', 0.95)])
+        assert result.is_flagged is False
+        assert result.categories == {'pii.private_date': 0.95}
+
+    def test_unknown_entity_group_ignored(self, service):
+        result = service._spans_to_result([span('organization', 0.99)])
+        assert result.is_flagged is False
+        assert result.categories == {}
+
+    def test_repeated_category_keeps_max_score(self, service):
+        result = service._spans_to_result([
+            span('private_phone', 0.6),
+            span('private_phone', 0.9),
+            span('private_phone', 0.7),
+        ])
+        assert result.categories == {'pii.private_phone': 0.9}
+
+    def test_multiple_categories(self, service):
+        result = service._spans_to_result([
+            span('private_person', 0.99),
+            span('private_email', 0.98),
+        ])
+        assert result.is_flagged is True
+        assert set(result.categories) == {'pii.private_person', 'pii.private_email'}
+
+
+# =============================================================================
+# moderate_content
+# =============================================================================
+
+class TestModerateContent:
+
+    @pytest.mark.asyncio
+    async def test_flags_pii(self, service):
+        service.pipeline.return_value = [span('private_email', 0.999, 'a@b.com')]
+        result = await service.moderate_content("My email is a@b.com")
+        assert result.is_flagged is True
+        assert result.categories == {'pii.private_email': 0.999}
+        service.pipeline.assert_called_once_with("My email is a@b.com")
+
+    @pytest.mark.asyncio
+    async def test_clean_content_passes(self, service):
+        service.pipeline.return_value = []
+        result = await service.moderate_content("The weather is nice today")
+        assert result.is_flagged is False
+        assert result.error is None
+
+    @pytest.mark.asyncio
+    async def test_pipeline_error_fails_open(self, service):
+        service.pipeline.side_effect = RuntimeError("model exploded")
+        result = await service.moderate_content("some text")
+        assert result.is_flagged is False
+        assert 'model exploded' in result.error
+
+    @pytest.mark.asyncio
+    async def test_failed_initialization_fails_open(self, basic_config):
+        service = PrivacyFilterModerationService(basic_config)
+        service.initialized = False
+        service.initialize = AsyncMock(return_value=False)
+        result = await service.moderate_content("some text")
+        assert result.is_flagged is False
+        assert 'initialization failed' in result.error
+
+
+# =============================================================================
+# moderate_batch
+# =============================================================================
+
+class TestModerateBatch:
+
+    @pytest.mark.asyncio
+    async def test_empty_batch(self, service):
+        assert await service.moderate_batch([]) == []
+
+    @pytest.mark.asyncio
+    async def test_batch_results_align_with_inputs(self, service):
+        service.pipeline.return_value = [
+            [span('private_person', 0.99)],
+            [],
+        ]
+        results = await service.moderate_batch(["Alice Smith", "hello world"])
+        assert len(results) == 2
+        assert results[0].is_flagged is True
+        assert results[1].is_flagged is False
+
+    @pytest.mark.asyncio
+    async def test_single_item_batch_span_list(self, service):
+        # For a single input the pipeline returns one span list, not a list of lists
+        service.pipeline.return_value = [span('secret', 0.97)]
+        results = await service.moderate_batch(["api key: sk-123"])
+        assert len(results) == 1
+        assert results[0].is_flagged is True
+
+    @pytest.mark.asyncio
+    async def test_batch_error_fails_open_per_item(self, service):
+        service.pipeline.side_effect = RuntimeError("boom")
+        results = await service.moderate_batch(["a", "b", "c"])
+        assert len(results) == 3
+        assert all(r.is_flagged is False and r.error for r in results)


### PR DESCRIPTION
Closes #166

Adds PII detection as a moderation provider using OpenAI's [privacy-filter](https://huggingface.co/openai/privacy-filter) token-classification model (Apache 2.0), running fully locally via the `transformers` pipeline. Follows the approach discussed in the issue: flag-and-block scoped to this PR, privacy-filter first with GLiNER-PII as a possible follow-up provider.

## What's included

**Implementation**
- `PrivacyFilterModerationService` in `server/ai_services/implementations/moderation/`, built on `TransformersBaseService` with a token-classification head instead of the causal-LM head. The model loads in a background thread and inference runs in the service executor, so the event loop is never blocked.
- Registered in `register_moderation_services()` alongside `openai`/`anthropic`/`ollama`. Enable with `safety.moderator: "privacy_filter"` in `guardrails.yaml`.
- The model's 8 PII span categories (`private_person`, `private_email`, `private_phone`, `private_address`, `account_number`, `private_url`, `private_date`, `secret`) map to `ModerationResult.categories` as `pii.<category>` scores. `is_flagged` is set when a configured category crosses the confidence threshold, so it composes with the existing safety config and guardrail pipeline like any other moderator.
- Config block in `moderators.yaml`: `model`, `device`, `threshold`, and `flag_categories`. Categories removed from `flag_categories` are still scored and logged for audit, just not flagged.
- Fail-open on init/inference errors, consistent with the other moderators.
- Uses the existing `huggingface` dependency profile (transformers + torch); no new dependencies.

**Tests**
- 20 unit tests in `test_privacy_filter_moderation.py` covering config parsing, span-to-result mapping (thresholds, category scoping, unknown labels, max-score aggregation), `moderate_content`/`moderate_batch`, and fail-open paths. The pipeline is mocked so CI never downloads the model. Existing moderation tests still pass (28/28).

**Playbook**
- `server/tests/test_services/playbook-pii-moderation.md`: 7 scenarios through the orbitchat UI (benign baseline, personal identifiers, secrets, threshold tuning, category scoping, fail-open on model failure, no-regression check for other moderators).

**Docs**
- `docs/security/pii-moderation.md`: setup, tuning, and limitations (including the model card's guidance that this is one layer in a privacy-by-design approach, not an anonymization guarantee).
- Moderators section of `docs/configuration.md` updated.

## Verification status

Unit tests and ruff pass locally. One honest caveat: I have not yet executed the playbook against the real model (my dev machine doesn't have torch installed and the model is a multi-GB download). The logic around the pipeline is fully unit-tested, but real-model detections through orbitchat (playbook steps 1-3) are unverified by me. Happy to iterate if the live model surfaces mapping issues, and glad to hear if you'd like anything structured differently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
